### PR TITLE
Moved rest of `sa_insights` iteration into `try` block

### DIFF
--- a/saUnused.py
+++ b/saUnused.py
@@ -30,9 +30,7 @@ def get_sa_insights(project_numbers):
     for project_num in project_numbers:
         try:
             sa_insights = recommender_client.list_insights(parent=f"projects/{project_num}/locations/global/insightTypes/google.iam.serviceAccount.Insight")
-        except exceptions.PermissionDenied as perm:
-            print(f"{perm}")
-        for insight in sa_insights:
+            for insight in sa_insights:
             if insight.insight_subtype == "SERVICE_ACCOUNT_USAGE":
                 email = insight.content["email"]
                 inactive_sa = json.dumps(
@@ -42,6 +40,10 @@ def get_sa_insights(project_numbers):
                 print(inactive_sa)
             else:
                 continue
+        except exceptions.PermissionDenied as perm:
+            print(f"{perm}")
+        except Exception as e:
+            print(e)
 
 
 def get_projects():


### PR DESCRIPTION
Addresses https://github.com/ScaleSec/gcp_sa_lister/issues/8

The `get_sa_insights` function had the core logic split between
the `try` block and the function code itself.  If the `try` was
successful, then the rest of the function operated as expected.

When the `except` was encountered, it would move to the function
code and fail because the `sa_insights` reference doesn't exist
in any scope.

The rest of the function logic was moved into the `try` block.

Additionally, a default `except` was added that will print the
exception encountered to stdout.

The function continuing to iterate through the list of projects
was preserved in this patch.